### PR TITLE
Removed duplicated selectitem code

### DIFF
--- a/app/src/main/java/com/poliveira/apps/materialtests/NavigationDrawerFragment.java
+++ b/app/src/main/java/com/poliveira/apps/materialtests/NavigationDrawerFragment.java
@@ -170,7 +170,6 @@ public class NavigationDrawerFragment extends Fragment implements NavigationDraw
 
     @Override
     public void onNavigationDrawerItemSelected(int position) {
-        mCallbacks.onNavigationDrawerItemSelected(position);
         selectItem(position);
     }
 


### PR DESCRIPTION
mCallbacks.onNavigationDrawerItemSelected(position);

This caused a duplicate call to "SelectItem".  This can be demoed by launching an activity from the nav menu and see that it creates two instances.
