### PR TITLE
Moved NavigationDrawer base classes to their own package

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/src/main/java/com/poliveira/apps/materialtests/MainActivity.java
+++ b/app/src/main/java/com/poliveira/apps/materialtests/MainActivity.java
@@ -7,6 +7,9 @@ import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.widget.Toast;
 
+import com.poliveria.apps.navigationdrawer.NavigationDrawerCallbacks;
+import com.poliveria.apps.navigationdrawer.NavigationDrawerFragment;
+
 
 public class MainActivity extends ActionBarActivity implements NavigationDrawerCallbacks {
 

--- a/app/src/main/java/com/poliveira/apps/materialtests/MainNavigationDrawerFragment.java
+++ b/app/src/main/java/com/poliveira/apps/materialtests/MainNavigationDrawerFragment.java
@@ -1,0 +1,23 @@
+package com.poliveira.apps.materialtests;
+
+
+import com.poliveria.apps.navigationdrawer.NavigationDrawerFragment;
+import com.poliveria.apps.navigationdrawer.NavigationItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Kevin Brey on 12/27/2014.
+ */
+public class MainNavigationDrawerFragment extends NavigationDrawerFragment {
+
+    @Override
+    public List<NavigationItem> getMenu() {
+        List<NavigationItem> items = new ArrayList<NavigationItem>();
+        items.add(new NavigationItem("item 1", getResources().getDrawable(R.drawable.ic_menu_check)));
+        items.add(new NavigationItem("item 2", getResources().getDrawable(R.drawable.ic_menu_check)));
+        items.add(new NavigationItem("item 3", getResources().getDrawable(R.drawable.ic_menu_check)));
+        return items;
+    }
+}

--- a/app/src/main/java/com/poliveria/apps/navigationdrawer/NavigationDrawerAdapter.java
+++ b/app/src/main/java/com/poliveria/apps/navigationdrawer/NavigationDrawerAdapter.java
@@ -1,4 +1,4 @@
-package com.poliveira.apps.materialtests;
+package com.poliveria.apps.navigationdrawer;
 
 import android.graphics.Color;
 import android.support.v7.widget.RecyclerView;
@@ -7,6 +7,8 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+
+import com.poliveira.apps.materialtests.R;
 
 import java.util.List;
 

--- a/app/src/main/java/com/poliveria/apps/navigationdrawer/NavigationDrawerCallbacks.java
+++ b/app/src/main/java/com/poliveria/apps/navigationdrawer/NavigationDrawerCallbacks.java
@@ -1,4 +1,4 @@
-package com.poliveira.apps.materialtests;
+package com.poliveria.apps.navigationdrawer;
 
 /**
  * Created by poliveira on 27/10/2014.

--- a/app/src/main/java/com/poliveria/apps/navigationdrawer/NavigationDrawerFragment.java
+++ b/app/src/main/java/com/poliveria/apps/navigationdrawer/NavigationDrawerFragment.java
@@ -1,4 +1,4 @@
-package com.poliveira.apps.materialtests;
+package com.poliveria.apps.navigationdrawer;
 
 import android.app.Activity;
 import android.app.Fragment;
@@ -16,13 +16,15 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.poliveira.apps.materialtests.R;
+
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Created by poliveira on 24/10/2014.
  */
-public class NavigationDrawerFragment extends Fragment implements NavigationDrawerCallbacks {
+public abstract class NavigationDrawerFragment extends Fragment implements NavigationDrawerCallbacks {
     private static final String PREF_USER_LEARNED_DRAWER = "navigation_drawer_learned";
     private static final String STATE_SELECTED_POSITION = "selected_navigation_drawer_position";
     private static final String PREFERENCES_FILE = "my_app_settings"; //TODO: change this to your file
@@ -133,13 +135,7 @@ public class NavigationDrawerFragment extends Fragment implements NavigationDraw
         mCallbacks = null;
     }
 
-    public List<NavigationItem> getMenu() {
-        List<NavigationItem> items = new ArrayList<NavigationItem>();
-        items.add(new NavigationItem("item 1", getResources().getDrawable(R.drawable.ic_menu_check)));
-        items.add(new NavigationItem("item 2", getResources().getDrawable(R.drawable.ic_menu_check)));
-        items.add(new NavigationItem("item 3", getResources().getDrawable(R.drawable.ic_menu_check)));
-        return items;
-    }
+    public abstract List<NavigationItem> getMenu();
 
     void selectItem(int position) {
         mCurrentSelectedPosition = position;

--- a/app/src/main/java/com/poliveria/apps/navigationdrawer/NavigationItem.java
+++ b/app/src/main/java/com/poliveria/apps/navigationdrawer/NavigationItem.java
@@ -1,4 +1,4 @@
-package com.poliveira.apps.materialtests;
+package com.poliveria.apps.navigationdrawer;
 
 import android.graphics.drawable.Drawable;
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,7 +26,7 @@
         <!-- android:layout_marginTop="?android:attr/actionBarSize"-->
         <fragment
             android:id="@+id/fragment_drawer"
-            android:name="com.poliveira.apps.materialtests.NavigationDrawerFragment"
+            android:name="com.poliveira.apps.materialtests.MainNavigationDrawerFragment"
             android:layout_width="@dimen/navigation_drawer_width"
             android:layout_height="match_parent"
             android:layout_gravity="start"

--- a/app/src/main/res/layout/activity_main_blacktoolbar.xml
+++ b/app/src/main/res/layout/activity_main_blacktoolbar.xml
@@ -25,7 +25,7 @@
     <fragment
         android:id="@+id/fragment_drawer"
         android:layout_marginTop="@dimen/abc_action_bar_default_height_material"
-        android:name="com.poliveira.apps.materialtests.NavigationDrawerFragment"
+        android:name="com.poliveira.apps.materialtests.MainNavigationDrawerFragment"
         android:layout_width="@dimen/navigation_drawer_width"
         android:layout_height="match_parent"
         android:layout_gravity="start"

--- a/app/src/main/res/layout/activity_main_topdrawer.xml
+++ b/app/src/main/res/layout/activity_main_topdrawer.xml
@@ -24,7 +24,7 @@
     <!-- android:layout_marginTop="?android:attr/actionBarSize"-->
     <fragment
         android:id="@+id/fragment_drawer"
-        android:name="com.poliveira.apps.materialtests.NavigationDrawerFragment"
+        android:name="com.poliveira.apps.materialtests.MainNavigationDrawerFragment"
         android:layout_width="@dimen/navigation_drawer_width"
         android:layout_height="match_parent"
         android:layout_gravity="start"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.14.0'
+        classpath 'com.android.tools.build:gradle:1.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Sat Dec 27 13:22:35 CST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
I restructured this in order to hide all of the NavigationDrawer implementation details in its own package. I also made the `NavigationDrawerFragement` abstract so it can only be used by extending it and implementing the `getMenu()` method. Finally, I updated the xml files to use the new implementation class.

This also contains the updates from #15 but does not depend on them.
